### PR TITLE
[NODEJS] Ajout de la configuration pour les SPA.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ language: sh
 
 before_deploy:
   - zip -r laravel.zip laravel
+  - zip -r nodejs-spa.zip nodejs-spa
   - zip -r symfony-mysql.zip symfony-mysql
 
 deploy:

--- a/nodejs-spa/.circleci/config.yml
+++ b/nodejs-spa/.circleci/config.yml
@@ -1,0 +1,140 @@
+version: 2
+
+jobs:
+  build:
+    docker:
+      - image: node
+    working_directory: ~/app
+
+    steps:
+      - checkout
+
+      - restore_cache:
+          keys:
+            - node-modules-{{ checksum "package.json" }}
+            - node-modules-
+
+      - run:
+          name: Install dependencies
+          command: npm install
+
+      - save_cache:
+          key: node-modules-{{ checksum "package.json" }}
+          paths:
+            - ./node_modules
+
+      - persist_to_workspace:
+          root: ~/app
+          paths:
+            - ./*
+
+
+  test:
+    docker:
+      - image: circleci/node
+    working_directory: ~/app
+
+    steps:
+      - attach_workspace:
+          at: ~/app
+
+      - run:
+          name: Launch tests
+          command: npm test
+
+
+  lint:
+    docker:
+      - image: circleci/node
+    working_directory: ~/app
+
+    steps:
+      - attach_workspace:
+          at: ~/app
+
+      - run:
+          name: Launch lint
+          command: npm run lint
+
+
+  deploy-staging: &deploy-job
+    docker:
+      - image: circleci/ruby
+        user: root
+    working_directory: /app
+
+    environment:
+      HEROKU_APP: my-app-staging
+
+    steps:
+      - checkout
+
+      - run:
+          name: Install dpl
+          command: |
+            gem install -N dpl
+
+      - run:
+          name: Deploy to Heroku
+          command: dpl --provider=heroku --app=$HEROKU_APP --api-key=$HEROKU_API_KEY --skip-cleanup=true
+
+
+  deploy-preprod:
+    <<: *deploy-job
+    environment:
+      HEROKU_APP: my-app-preprod
+
+  deploy-prod:
+    <<: *deploy-job
+    environment:
+      HEROKU_APP: my-app-prod
+
+
+filter-staging: &filter-staging
+  filters:
+    branches:
+      only: master
+
+filter-preprod-prod: &filter-preprod-prod
+  filters:
+    branches:
+      ignore: /.*/
+    tags:
+      only:
+        /\d+\.\d+\.\d+/
+
+
+workflows:
+  version: 2
+
+  test:
+    jobs:
+      - build
+      - test:
+          requires:
+            - build
+      - lint:
+          requires:
+            - build
+
+  deploy-staging:
+    jobs:
+      - deploy-staging:
+          <<: *filter-staging
+
+  deploy:
+    jobs:
+      - hold_preprod:
+          <<: *filter-preprod-prod
+          type: approval
+      - deploy-preprod:
+          <<: *filter-preprod-prod
+          requires:
+            - hold_preprod
+      - hold_prod:
+          <<: *filter-preprod-prod
+          type: approval
+      - deploy-prod:
+          <<: *filter-preprod-prod
+          requires:
+            - hold_prod

--- a/nodejs-spa/Procfile
+++ b/nodejs-spa/Procfile
@@ -1,0 +1,1 @@
+web: npm run start

--- a/nodejs-spa/README.md
+++ b/nodejs-spa/README.md
@@ -1,0 +1,44 @@
+## Introduction
+
+Tous les fichiers ajoutés proviennent du
+[StarterKit Heroku](https://github.com/Linkvalue-Booster/configs).
+
+Le but de ce StarterKit est d'aider les développeurs dans la création des
+environnements Heroku pour leurs applications.
+
+## En quoi ça consiste ?
+
+Le StarterKit Heroku pour NodeJS en Single Page Application copie un ensemble de
+fichiers, dont :
+- un fichier app.json qui assiste les développeurs dans la création de leur
+  application Heroku
+- un fichier Procfile qui définit la ligne de commande à lancer au démarrage de
+  l'application
+- un fichier .circleci/config.yml pour définir la logique derrière
+  l'intégration continue et le déploiement continu statiquement les fichiers
+
+Tous ces fichiers ont été configurés pour avoir un certain comportement par
+défaut. Certaines de ces configurations utilisent des variables bidons, c'est
+notamment le cas pour la configuration CircleCI dont le but est de donner un
+pipeline par défaut tel que décrit dans la documentation sur Notion.
+
+Ainsi, il est recommandé de valider les différents fichiers et de les modifier
+en fonction des besoins de l'application.
+
+## Les actions à effectuer
+
+Une fois que les fichiers ont été modifiés conformément aux besoins de
+l'application, voici les étapes à effectuer :
+
+1. Pour créer l'environnement de staging, il suffit de se rendre à l'adresse
+   suivante : `https://heroku.com/deploy?template=[REPO_URL]` en remplaçant
+   `[REPO_URL]` par l'URL du dépôt qui doit ressembler à
+   `https://github.com/user/repo`.
+
+2. Ajouter le projet dans CircleCI afin d'activer l'intégration continue et le
+   déploiement continu sur le projet.
+
+Une fois ces étapes effectuées, il est fortement recommandé de :
+- **se référer à la documentation** mise à disposition sur Notion ;
+- **modifier ce README pour qu'il reflète ce qui est fait dans le projet** et
+  non ce qui est lié à sa création.

--- a/nodejs-spa/app.json
+++ b/nodejs-spa/app.json
@@ -1,0 +1,24 @@
+{
+  "name": "Booster NodeJS Single Page App Staging",
+  "stack": "heroku-18",
+  "env": {
+    "NODE_ENV": "production"
+  },
+  "scripts": {
+
+  },
+  "formation": {
+    "web": {
+      "quantity": 1,
+      "size": "free"
+    }
+  },
+  "addons": [
+
+  ],
+  "buildpacks": [
+    {
+      "url": "heroku/nodejs"
+    }
+  ]
+}


### PR DESCRIPTION
Ajout de la configuration pour les applications en single page, donc
tout ce qui touche à du ReactJS ou du VueJS en standalone, ou dans une
configuration avec 2 repos séparés (repo API + repo Front).

L'idée ici est de servir statiquement les fichiers en passant par le
Buildpack Static de Heroku. Ainsi, cela nécessite de passer par le
fichier `static.json` pour faire la configuration du serveur web.